### PR TITLE
Support dependent clojure files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "sbt-clojure"
 
 organization := "com.unhandledexpression"
 
-version := "0.1"
+version := "0.2-SNAPSHOT"
 
 scalaVersion := "2.10.2"
 

--- a/src/main/scala/ClojurePlugin.scala
+++ b/src/main/scala/ClojurePlugin.scala
@@ -58,7 +58,7 @@ object ClojurePlugin extends Plugin {
         if(nb > 0){
           val s: TaskStreams = streams.value
           s.log.info("Start Compiling Test Clojure sources")
-          val classpath : Seq[File] = update.value.select( configurationFilter(name = "*") ) ++ Seq((classDirectory in Test).value) ++ Seq((classDirectory in Compile).value)
+          val classpath : Seq[File] = update.value.select( configurationFilter(name = "*") ) ++ Seq((classDirectory in Test).value) ++ Seq((classDirectory in Compile).value) ++ Seq(sourceDirectory)
           val stubDirectory : File = (sourceManaged in Test).value
           val destinationDirectory : File = (classDirectory in Test).value
 

--- a/src/main/scala/ClojurePlugin.scala
+++ b/src/main/scala/ClojurePlugin.scala
@@ -26,7 +26,7 @@ object ClojurePlugin extends Plugin {
         if(nb > 0){
           val s: TaskStreams = streams.value
           s.log.info("Start Compiling Clojure sources")
-          val classpath : Seq[File] = update.value.select( configurationFilter(name = "*") ) ++ Seq((classDirectory in Compile).value)
+          val classpath : Seq[File] = update.value.select( configurationFilter(name = "*") ) ++ Seq((classDirectory in Compile).value) ++ Seq(sourceDirectory)
           val stubDirectory : File = (sourceManaged in Compile).value
           val destinationDirectory : File = (classDirectory in Compile).value
 


### PR DESCRIPTION
By adding the source directory of clojure files on the classpath, when compiling the clojure files, any dependencies can be compiled/loaded as required.
